### PR TITLE
docs: adjust URL to use in Lefthook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ example content below:
 # .lefthook.yaml
 ---
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
-    ref: v1.2.0
+  - git_url: https://github.com/boozt-platform/lefthook.git
+    ref: v1.3.0
     configs:
       # lint commit messages based by the conventional commits
       - hooks/commitlint/.lefthook.yaml


### PR DESCRIPTION
#### Summary

We have experienced issues when initiating the Lefthook with SSH url, so better to change that to a HTTPS
