### PR TITLE
feat: ignore pnpm lock.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,9 @@
 # https://yamllint.readthedocs.io/en/stable/configuration.html
 extends: default
 
+# Ignore specific files (regex). Exclude pnpm-lock.yaml from linting because it's a generated lockfile.
+ignore: '^pnpm-lock\.yaml$'
+
 yaml-files:
   - '*.yaml'
   - '*.yml'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 [<img src="https://raw.githubusercontent.com/boozt-platform/branding/main/assets/img/platform-logo.png" width="350"/>][homepage]
 
-[![GitHub Tag (latest SemVer)](https://img.shields.io/github/v/tag/boozt-platform/lefthook.svg?label=latest&sort=semver)][releases]
+[![GitHub Tag (latest SemVer)](https://img.shields.io/github/v/tag/yacosta738/lefthook.svg?label=latest&sort=semver)][releases]
 [![license](https://img.shields.io/badge/license-mit-brightgreen.svg)][license]
 <!-- markdownlint-restore -->
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ example content below:
 # .lefthook.yaml
 ---
 remotes:
-  - git_url: https://github.com/boozt-platform/lefthook.git
+  - git_url: https://github.com/yacosta738/lefthook.git
     ref: v1.3.0
     configs:
       # lint commit messages based by the conventional commits
@@ -110,10 +110,10 @@ please follow the [Contribution Guidelines][contributing]
 This project is licensed under the MIT. Please see [LICENSE][license] for
 full details.
 
-[homepage]: https://github.com/boozt-platform/lefthook
-[releases]: https://github.com/boozt-platform/lefthook/releases
-[issues]: https://github.com/boozt-platform/lefthook/issues
-[pull-request]: https://github.com/boozt-platform/lefthook/pulls
+[homepage]: https://github.com/yacosta738/lefthook
+[releases]: https://github.com/yacosta738/lefthook/releases
+[issues]: https://github.com/yacosta738/lefthook/issues
+[pull-request]: https://github.com/yacosta738/lefthook/pulls
 [contributing]: ./docs/CONTRIBUTING.md
 [license]: ./LICENSE
 [boozt]: https://www.boozt.com/

--- a/hooks/commitlint/README.md
+++ b/hooks/commitlint/README.md
@@ -9,7 +9,7 @@ framework. For a full information take a look at CONTRIBUTING.md guideline
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint commit messages based by the conventional commits

--- a/hooks/hadolint/README.md
+++ b/hooks/hadolint/README.md
@@ -8,7 +8,7 @@ practices. [https://github.com/hadolint/hadolint](https://github.com/hadolint/ha
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint Dockerfiles

--- a/hooks/jsonlint/README.md
+++ b/hooks/jsonlint/README.md
@@ -14,7 +14,7 @@ the `git add`).
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # validate the JSON files

--- a/hooks/license-checker/README.md
+++ b/hooks/license-checker/README.md
@@ -9,7 +9,7 @@ files.
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # Check if the license headers are present in the files

--- a/hooks/markdown-lint/README.md
+++ b/hooks/markdown-lint/README.md
@@ -10,7 +10,7 @@ For a full configuration and documentation [follow this link](https://github.com
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint the markdown (.md) files

--- a/hooks/shellcheck/README.md
+++ b/hooks/shellcheck/README.md
@@ -7,7 +7,7 @@ A shell script static analysis tool. [https://github.com/koalaman/shellcheck](ht
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint shell scripts

--- a/hooks/terraform/README.md
+++ b/hooks/terraform/README.md
@@ -38,7 +38,7 @@ You can also run the Terraform commands directly using Lefthook:
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # terraform validation, fmt and tests

--- a/hooks/yamllint/README.md
+++ b/hooks/yamllint/README.md
@@ -10,7 +10,7 @@ For a full configuration and documentation [follow this link](https://yamllint.r
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # A linter for YAML files.


### PR DESCRIPTION
This pull request makes several repository-wide updates, primarily rebranding all references from `boozt-platform/lefthook` to `yacosta738/lefthook` across documentation and configuration files. Additionally, it introduces Dependabot for GitHub Actions and updates YAML linting configuration. Below are the most important changes:

**Repository Rebranding:**

* Updated all documentation and configuration examples to reference `yacosta738/lefthook` instead of `boozt-platform/lefthook`, including in `README.md`, hook documentation, and example configuration files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R116) [[4]](diffhunk://#diff-d7768da1639c8dabf810c6eb907f450d024a59bdca4874c8a85fff1e167d72fbL12-R12) [[5]](diffhunk://#diff-f39801d70146ab4821a5db3a5c27690dff7ff0cb6799a67e908d2cbc68c9f112L11-R11) [[6]](diffhunk://#diff-d204291c840be8b689763d411752ece8914f6008a3a3a56348552de85f54a889L17-R17) [[7]](diffhunk://#diff-6b6e858026272367a19898b90141a924e43d598ff43cf4a41c64c7b85ee5bfe2L12-R12) [[8]](diffhunk://#diff-7ab58a436122a7263772f29c7bd192ecb6ece51c102d3c69dfb6e70ca251dda8L13-R13) [[9]](diffhunk://#diff-63905f9421e5fce174187828e4cc09a8efe7a98afcacb1d0d7321bcfd1cb69f7L10-R10) [[10]](diffhunk://#diff-01c4237c43c069b608216e9ac142254dd6e5b8567cb0b5288b2512065511b223L41-R41) [[11]](diffhunk://#diff-c401e81e59f2855f97aaebf0ecefd8557688df5eb1654a8b220a0bee541c019aL13-R13)

**Dependency Management:**

* Added a `.github/dependabot.yml` configuration to enable monthly updates for GitHub Actions dependencies, grouping all actions together.

**Linting Configuration:**

* Updated `.yamllint.yaml` to ignore `pnpm-lock.yaml`, since it's a generated lockfile, and clarified which YAML files to lint.[Copilot is generating a summary...]