### PR TITLE
feat: ignore yaml files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 blank_issues_enabled: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 
 ---

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 
 # For more information about the configuration file, see:

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 extends:

--- a/.lefthook/commit-msg/commitlint.sh
+++ b/.lefthook/commit-msg/commitlint.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 
 # Run commitlint.sh script to lint commit messages
 # based on the conventional commits specification.
 # https://www.conventionalcommits.org/en/v1.0.0/
-# 
+#
 # Create a new .commitlint configuration environment file
 # in the root project to override the default configuration.
 

--- a/.lefthook/pre-commit/license-checker.sh
+++ b/.lefthook/pre-commit/license-checker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 
 # Script is a pre-commit hook to check if the staged files

--- a/.license-checker.txt
+++ b/.license-checker.txt
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 SPDX-License-Identifier: MIT

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 # Default state for all rules

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,8 +5,16 @@
 # https://yamllint.readthedocs.io/en/stable/configuration.html
 extends: default
 
-# Ignore specific files (regex). Exclude pnpm-lock.yaml from linting because it's a generated lockfile.
-ignore: '^pnpm-lock\.yaml$'
+# Ignore specific files (regex). Exclude lock files and generated files from linting.
+ignore: |
+  pnpm-lock.yaml
+  *.generated.yaml
+  *.generated.yml
+  **/node_modules/**
+  **/vendor/**
+  .git/**
+
+ignore-from-file: .gitignore
 
 yaml-files:
   - '*.yaml'

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,9 @@
 # https://yamllint.readthedocs.io/en/stable/configuration.html
 extends: default
 
+# Ignore specific files (regex). Exclude pnpm-lock.yaml from linting because it's a generated lockfile.
+ignore: '^pnpm-lock\.yaml$'
+
 yaml-files:
   - '*.yaml'
   - '*.yml'

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 # For more information about the configuration file, see:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Boozt Platform
+Copyright (c) 2024 Yuniel Acosta
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 [<img src="https://raw.githubusercontent.com/boozt-platform/branding/main/assets/img/platform-logo.png" width="350"/>][homepage]
 
-[![GitHub Tag (latest SemVer)](https://img.shields.io/github/v/tag/boozt-platform/lefthook.svg?label=latest&sort=semver)][releases]
+[![GitHub Tag (latest SemVer)](https://img.shields.io/github/v/tag/yacosta738/lefthook.svg?label=latest&sort=semver)][releases]
 [![license](https://img.shields.io/badge/license-mit-brightgreen.svg)][license]
 <!-- markdownlint-restore -->
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ example content below:
 ---
 remotes:
   - git_url: https://github.com/yacosta738/lefthook.git
-    ref: v1.3.0
+    ref: v1.0.0
     configs:
       # lint commit messages based by the conventional commits
       - hooks/commitlint/.lefthook.yaml

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ example content below:
 # .lefthook.yaml
 ---
 remotes:
-  - git_url: https://github.com/boozt-platform/lefthook.git
+  - git_url: https://github.com/yacosta738/lefthook.git
     ref: v1.3.0
     configs:
       # lint commit messages based by the conventional commits
@@ -110,10 +110,10 @@ please follow the [Contribution Guidelines][contributing]
 This project is licensed under the MIT. Please see [LICENSE][license] for
 full details.
 
-[homepage]: https://github.com/boozt-platform/lefthook
-[releases]: https://github.com/boozt-platform/lefthook/releases
-[issues]: https://github.com/boozt-platform/lefthook/issues
-[pull-request]: https://github.com/boozt-platform/lefthook/pulls
+[homepage]: https://github.com/yacosta738/lefthook
+[releases]: https://github.com/yacosta738/lefthook/releases
+[issues]: https://github.com/yacosta738/lefthook/issues
+[pull-request]: https://github.com/yacosta738/lefthook/pulls
 [contributing]: ./docs/CONTRIBUTING.md
 [license]: ./LICENSE
 [boozt]: https://www.boozt.com/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -107,7 +107,7 @@ To create a new hook, follow these steps:
 within license header as the following code below:
 
     ```yaml
-    # SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+    # SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
     # SPDX-License-Identifier: MIT
     ---
     pre-commit:
@@ -152,7 +152,7 @@ license comment block. This block should be added at the top of each
 source code file.
 
 ```text
-SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 SPDX-License-Identifier: MIT
 ```
 

--- a/hooks/commitlint/.lefthook.yaml
+++ b/hooks/commitlint/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 commit-msg:

--- a/hooks/commitlint/README.md
+++ b/hooks/commitlint/README.md
@@ -9,7 +9,7 @@ framework. For a full information take a look at CONTRIBUTING.md guideline
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint commit messages based by the conventional commits

--- a/hooks/hadolint/.lefthook.yaml
+++ b/hooks/hadolint/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/hadolint/README.md
+++ b/hooks/hadolint/README.md
@@ -8,7 +8,7 @@ practices. [https://github.com/hadolint/hadolint](https://github.com/hadolint/ha
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint Dockerfiles

--- a/hooks/jsonlint/.lefthook.yaml
+++ b/hooks/jsonlint/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/jsonlint/README.md
+++ b/hooks/jsonlint/README.md
@@ -14,7 +14,7 @@ the `git add`).
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # validate the JSON files

--- a/hooks/license-checker/.lefthook.yaml
+++ b/hooks/license-checker/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/license-checker/README.md
+++ b/hooks/license-checker/README.md
@@ -9,7 +9,7 @@ files.
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # Check if the license headers are present in the files

--- a/hooks/markdown-lint/.lefthook.yaml
+++ b/hooks/markdown-lint/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/markdown-lint/README.md
+++ b/hooks/markdown-lint/README.md
@@ -10,7 +10,7 @@ For a full configuration and documentation [follow this link](https://github.com
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint the markdown (.md) files

--- a/hooks/shellcheck/.lefthook.yaml
+++ b/hooks/shellcheck/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/shellcheck/README.md
+++ b/hooks/shellcheck/README.md
@@ -7,7 +7,7 @@ A shell script static analysis tool. [https://github.com/koalaman/shellcheck](ht
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # lint shell scripts

--- a/hooks/terraform/.lefthook.yaml
+++ b/hooks/terraform/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 terraform:

--- a/hooks/terraform/README.md
+++ b/hooks/terraform/README.md
@@ -38,7 +38,7 @@ You can also run the Terraform commands directly using Lefthook:
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # terraform validation, fmt and tests

--- a/hooks/yamllint/.lefthook.yaml
+++ b/hooks/yamllint/.lefthook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Boozt Fashion, AB
+# SPDX-FileCopyrightText: Copyright Yuniel Acosta, CU
 # SPDX-License-Identifier: MIT
 ---
 pre-commit:

--- a/hooks/yamllint/README.md
+++ b/hooks/yamllint/README.md
@@ -10,7 +10,7 @@ For a full configuration and documentation [follow this link](https://yamllint.r
 ```yaml
 # .lefthook.yaml
 remotes:
-  - git_url: git@github.com:boozt-platform/lefthook
+  - git_url: git@github.com:yacosta738/lefthook
     ref: [tag]
     configs:
       # A linter for YAML files.


### PR DESCRIPTION
This pull request updates project metadata and documentation to reflect a new copyright holder and repository location. The changes ensure all references, legal notices, and documentation now point to Yuniel Acosta and the new GitHub repository.

**Licensing and Copyright**

* Updated copyright notices in all configuration, license, and script files to "Yuniel Acosta, CU" and updated the `LICENSE` file accordingly. [[1]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L1-R1) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R1) [[3]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L1-R1) [[4]](diffhunk://#diff-00e49778078c450a994915211c89c6f0bc83c69d863552a988cec28ce885c1d3L1-R1) [[5]](diffhunk://#diff-da8ef5efa1ccda6d9b17188681178970430bccd3768cd4e9f584a673e05cdb17L3-R3) [[6]](diffhunk://#diff-635b64a6a0538aedd364795ef47d966775fd3424e1cd75fbff24068ada0b90caL3-R3) [[7]](diffhunk://#diff-43193187fb886808bb43bfb0c341e9f6fe14b86532cc5cf24fad3d879c7b2959L1-R1) [[8]](diffhunk://#diff-39aecbc26791dd03b9a4fdc1f856769ea73308294b7111d70f279ac9bdef35bdL1-R1) [[9]](diffhunk://#diff-6d64954d09d48e7ad2d33d6311f8e813c1dffdc4b4cad27b008a132f786eb9ccL1-R18) [[10]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[11]](diffhunk://#diff-89ec6b4b24c366e9e639a80aecbd4c019e54b203d77badc4c63fb0dbc366bfeaL1-R1) [[12]](diffhunk://#diff-f67dff4c9f1dc7c70437fb87011f7fb7fe7dd21ee08e7ce52bb6ed456e0f1e68L1-R1) [[13]](diffhunk://#diff-6f986479d2677ed2244c38b55b62a733268a4003d762ec9e16fca8e11e53fe7fL1-R1) [[14]](diffhunk://#diff-906ae86b4d2135afb594363f73ff5aa340dabcb094870438248671552c05791cL1-R1) [[15]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L110-R110) [[16]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L155-R155)

**Repository and Documentation Updates**

* Changed all repository URLs and references in `README.md`, documentation, and example configuration files from `boozt-platform/lefthook` to `yacosta738/lefthook`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R116) [[4]](diffhunk://#diff-d7768da1639c8dabf810c6eb907f450d024a59bdca4874c8a85fff1e167d72fbL12-R12) [[5]](diffhunk://#diff-f39801d70146ab4821a5db3a5c27690dff7ff0cb6799a67e908d2cbc68c9f112L11-R11) [[6]](diffhunk://#diff-d204291c840be8b689763d411752ece8914f6008a3a3a56348552de85f54a889L17-R17)

**Configuration Improvements**

* Added a new `.github/dependabot.yml` to enable monthly GitHub Actions dependency updates.
* Enhanced `.yamllint.yaml` with ignore patterns and support for `.gitignore` to exclude lock, generated, and vendor files from linting.